### PR TITLE
Update CTA buttons and open buy link in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
           </div>
 
           <ul class="actions" style="margin-top: 3em">
-            <li><a href="https://square.link/u/rolv7Oo6" class="button primary large">BUY NOW</a></li>
+            <li><a href="https://square.link/u/rolv7Oo6" class="button primary large" target="_blank">BUY NOW</a></li>
           </ul>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
             </section>
           </div>
           <ul class="actions">
-            <li><a href="#" class="button">Get Started</a></li>
+            <li><a href="#contact" class="button scrolly">Get Started</a></li>
           </ul>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
           </div>
           <div style="text-align: center; margin-top: 3em">
             <ul class="actions">
-              <li><a href="#" class="button">Learn More</a></li>
+              <li><a href="#contact" class="button scrolly">Learn More</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
This PR updates call-to-action buttons to scroll to the contact section and ensures the book purchase link opens in a new tab.

## Problem
The "Get Started" and "Learn More" buttons were previously non-functional placeholders (`#`), and clicking "Buy Now" navigated the user away from the current site.

## Solution
Internal navigation buttons were updated to anchor to the `#contact` section using the `scrolly` class, and the external purchase link was modified to open in a new browser tab.

## Key Changes
- Updated "Get Started" button in the Consulting section to link to `#contact`.
- Updated "Learn More" button in the Tutoring section to link to `#contact`.
- Added `target="_blank"` to the "BUY NOW" button to preserve the current session.

## Files Changed
- `index.html`: Modified `href` and `target` attributes on specific anchor tags.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f07ae8ac58e47c38f1f303f05f6b877/spark-space)

👀 [Preview Link](https://7f07ae8ac58e47c38f1f303f05f6b877-spark-space.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f07ae8ac58e47c38f1f303f05f6b877</projectId>-->
<!--<branchName>spark-space</branchName>-->